### PR TITLE
Add ability to inherit schema attributes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,10 @@ function wrap(schema, target) {
 
   if (parent.name) wrap(schema, parent);
 
+  if (target.schema && typeof target.schema == 'object') {
+    schema.add(target.schema);
+  }
+
   staticProps.forEach(name => {
     let method = Object.getOwnPropertyDescriptor(target, name);
     if (typeof method.value == 'function') schema.static(name, method.value);


### PR DESCRIPTION
Really useful mongoose class wrapper however I have found it useful to also define attributes with the classes. Here is how this would be used.

Lets say you are creating a resource base model which is versionable. This would be the class definition:

``` javascript
class Resource {
  static show(id) {
    return this.findById(id).exec();
  }
}
Resource.schema = {
  version: { type: Number, default:0 }
}
```

Then to create a extension of a resource, a lesson shall we say that that has a name

``` javascript
class Lesson extends Resource {}
Lesson.schema = {
  name: String
}
```

Therefore the resulting mongoose Schema would have both attributes. Let me know if this is not very clear.

Thanks again for a useful utility
