### PR TITLE
Add support for options

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,13 @@ class UserModel {
 
 }
 
+//posible options, for instance if you want to ignore getter and setters put
+options={
+	ignore_getters_and_setters:true
+}
+
 // Add methods from class to schema
-userSchema.plugin(loadClass, UserModel);
+userSchema.plugin(loadClass, {target:UserModel,options:options});
 
 // Export mongoose model
 export default mongoose.model('User', userSchema);

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ class UserModel {
 }
 
 //posible options, for instance if you want to ignore getter and setters put
-options={
-	ignore_getters_and_setters:true
+const options={
+	ignoreGettersAndSetters:true
 }
 
 // Add methods from class to schema

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,2 @@
-declare function loadClass(schema: any, target: any): void;
+declare function loadClass(schema: any, {target: any,options: object}:object): void;
 export = loadClass;

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
-function wrap(schema, target, hooks = []) {
+function wrap(schema,params, hooks = []) {
+  let {options={},target=params} = params;
   let proto = target.prototype;
   let parent = Object.getPrototypeOf(target);
   let staticProps = Object.getOwnPropertyNames(target);
@@ -39,8 +40,11 @@ function wrap(schema, target, hooks = []) {
   instanceProps.forEach(name => {
     let method = Object.getOwnPropertyDescriptor(proto, name);
     if (typeof method.value == 'function') schema.method(name, method.value);
-    if (typeof method.get == 'function') schema.virtual(name).get(method.get);
-    if (typeof method.set == 'function') schema.virtual(name).set(method.set);
+    if (!options.ignore_getters_and_setters){
+      if (typeof method.get == 'function') schema.virtual(name).get(method.get);
+      if (typeof method.set == 'function') schema.virtual(name).set(method.set);
+    }
+    
   });
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
-function wrap(schema,params, hooks = []) {
-  let {options={},target=params} = params;
+function wrap(schema, params, hooks = []) {
+  let {options = {}, target = params} = params;
   let proto = target.prototype;
   let parent = Object.getPrototypeOf(target);
   let staticProps = Object.getOwnPropertyNames(target);
@@ -40,7 +40,7 @@ function wrap(schema,params, hooks = []) {
   instanceProps.forEach(name => {
     let method = Object.getOwnPropertyDescriptor(proto, name);
     if (typeof method.value == 'function') schema.method(name, method.value);
-    if (!options.ignore_getters_and_setters){
+    if (!options.ignoreGettersAndSetters){
       if (typeof method.get == 'function') schema.virtual(name).get(method.get);
       if (typeof method.set == 'function') schema.virtual(name).set(method.set);
     }


### PR DESCRIPTION
add support to ignore_getters_and_setter options so ecma6 that have
virtual properties that located in the schema will work
for instance if you have class
```javascript
class User{
  get name (){
    return this._namel
  }
  set name(value){
    this._name=valuel
  }
}
const UserSchema = new Schema ({
  name:String
});
UserSchema.plugin(loadClass,User);
```
will throw an exception , let's let the user to decide if s/he wants to add virtual prorties or not